### PR TITLE
Chrobalt Java Bridgef

### DIFF
--- a/base/android/java/src/org/chromium/base/library_loader/LibraryLoader.java
+++ b/base/android/java/src/org/chromium/base/library_loader/LibraryLoader.java
@@ -741,6 +741,10 @@ public class LibraryLoader {
         setEnvForNative();
         preloadAlreadyLocked(appInfo.packageName, inZygote);
         for (String library : NativeLibraries.LIBRARIES) {
+            if (library.equals("starboard.cr")) {
+                continue;
+            }
+
             System.loadLibrary(library);
         }
     }

--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -174,6 +174,7 @@ shared_library("libcobalt_content_shell_content_view") {
     "//content/shell/android:content_shell_jni_headers",
     "//media",
     "//skia",
+    "//starboard",
   ]
 
   # Explicit dependency required for JNI registration to be able to

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -63,6 +63,11 @@ public class StarboardBridge {
     StarboardBridge getStarboardBridge();
   }
 
+  static {
+    System.loadLibrary("starboard.cr");
+  }
+
+
   private CobaltSystemConfigChangeReceiver sysConfigChangeReceiver;
   private CobaltTextToSpeechHelper ttsHelper;
   // TODO(cobalt): Re-enable these classes or remove if unnecessary.
@@ -115,7 +120,6 @@ public class StarboardBridge {
     // Make sure the JNI stack is properly initialized first as there is
     // race condition as soon as any of the following objects creates a new thread.
     // nativeInitialize();
-
     this.appContext = appContext;
     this.activityHolder = activityHolder;
     this.serviceHolder = serviceHolder;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java
@@ -42,7 +42,7 @@ public class VideoSurfaceView extends SurfaceView {
 
     // Reset video surface on nexus player to avoid b/159073388.
     if (needResetSurfaceList.contains(Build.MODEL)) {
-      // nativeSetNeedResetSurface();
+      nativeSetNeedResetSurface();
     }
   }
 
@@ -75,9 +75,9 @@ public class VideoSurfaceView extends SurfaceView {
     // punch-out video when the position / size is animated.
   }
 
-  // private static native void nativeOnVideoSurfaceChanged(Surface surface);
+  private static native void nativeOnVideoSurfaceChanged(Surface surface);
 
-  // private static native void nativeSetNeedResetSurface();
+  private static native void nativeSetNeedResetSurface();
 
   private class SurfaceHolderCallback implements SurfaceHolder.Callback {
 
@@ -86,7 +86,8 @@ public class VideoSurfaceView extends SurfaceView {
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
       currentSurface = holder.getSurface();
-      // nativeOnVideoSurfaceChanged(currentSurface);
+      Log.e(TAG, "Colin nativeOnVideoSurfaceChanged");
+      nativeOnVideoSurfaceChanged(currentSurface);
     }
 
     @Override
@@ -101,7 +102,7 @@ public class VideoSurfaceView extends SurfaceView {
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
       currentSurface = null;
-      // nativeOnVideoSurfaceChanged(currentSurface);
+      nativeOnVideoSurfaceChanged(currentSurface);
     }
   }
 

--- a/cobalt/cobalt_main_delegate.cc
+++ b/cobalt/cobalt_main_delegate.cc
@@ -15,8 +15,32 @@
 #include "cobalt/cobalt_main_delegate.h"
 #include "cobalt/cobalt_content_browser_client.h"
 #include "content/public/browser/render_frame_host.h"
+#include "starboard/media.h"
+#include "starboard/player.h"
+// #include "base/android/jni_android.h"
+// #include "starboard/android/shared/jni_env_ext.h"
 
 namespace cobalt {
+
+void PlayerDeallocateSampleFunc(SbPlayer player,
+                                void* context,
+                                const void* sample_buffer) {}
+
+void PlayerDecoderStatusFunc(SbPlayer player,
+                             void* context,
+                             SbMediaType type,
+                             SbPlayerDecoderState state,
+                             int ticket) {}
+
+void PlayerStatusFunc(SbPlayer player,
+                      void* context,
+                      SbPlayerState state,
+                      int ticket) {}
+
+void PlayerErrorFunc(SbPlayer player,
+                     void* context,
+                     SbPlayerError error,
+                     const char* message) {}
 
 CobaltMainDelegate::CobaltMainDelegate(bool is_content_browsertests)
     : content::ShellMainDelegate(is_content_browsertests) {}
@@ -32,6 +56,39 @@ CobaltMainDelegate::CreateContentBrowserClient() {
 absl::optional<int> CobaltMainDelegate::PostEarlyInitialization(
     InvokedIn invoked_in) {
   content::RenderFrameHost::AllowInjectingJavaScript();
+
+  // Debug code just to attempt SbPlayerCreation on Startup
+  SbPlayerCreationParam creation_param = {};
+
+  creation_param.drm_system = kSbDrmSystemInvalid;
+
+  creation_param.audio_stream_info.codec = kSbMediaAudioCodecOpus;
+  creation_param.audio_stream_info.mime = "";
+  creation_param.audio_stream_info.number_of_channels = 2;
+  creation_param.audio_stream_info.samples_per_second = 48000;
+  creation_param.audio_stream_info.bits_per_sample = 16;
+  creation_param.audio_stream_info.audio_specific_config_size = 0;
+  creation_param.audio_stream_info.audio_specific_config = "";
+
+  creation_param.video_stream_info.codec = kSbMediaVideoCodecVp9;
+  creation_param.video_stream_info.mime = "";
+  creation_param.video_stream_info.max_video_capabilities = "";
+  creation_param.video_stream_info.frame_width = 1920;
+  creation_param.video_stream_info.frame_height = 1080;
+  creation_param.output_mode = kSbPlayerOutputModePunchOut;
+
+  void* context = nullptr;
+  SbDecodeTargetGraphicsContextProvider* provider = nullptr;
+  SbPlayer player =
+      SbPlayerCreate(kSbWindowInvalid, &creation_param,
+                     PlayerDeallocateSampleFunc, PlayerDecoderStatusFunc,
+                     PlayerStatusFunc, PlayerErrorFunc, context, provider);
+  DCHECK(player);
+  SbPlayerDestroy(player);
+  SbDrmSystemIsValid(nullptr);
+  SbDrmTicketIsValid(0);
+
+  LOG(INFO) << "Colin DCHECK(player) passed";
 
   return ShellMainDelegate::PostEarlyInitialization(invoked_in);
 }


### PR DESCRIPTION
This change enables communication between Java and JavaScript in Cobalt's Android app. It introduces a Java bridge, allowing JavaScript to call Java methods and access Java objects. This is achieved by injecting Java objects into the WebView and loading corresponding JavaScript code. An example (CobaltJavaScriptAndroidObjectExample.java, example.js) demonstrates the usage.

b/372558900